### PR TITLE
Dont add security parameters if they already exist hls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@antmedia/web_player",
-  "version": "2.8.0-SNAPSHOT",
+  "version": "2.8.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@antmedia/web_player",
-      "version": "2.8.0-SNAPSHOT",
+      "version": "2.8.2",
       "license": "ISC",
       "dependencies": {
         "@antmedia/videojs-webrtc-plugin": "^1.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@antmedia/web_player",
-  "version": "2.8.2",
+  "version": "2.8.3-ALPHA-29-03-2024",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@antmedia/web_player",
-      "version": "2.8.2",
+      "version": "2.8.3-ALPHA-29-03-2024",
       "license": "ISC",
       "dependencies": {
         "@antmedia/videojs-webrtc-plugin": "^1.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@antmedia/web_player",
-  "version": "2.8.3-ALPHA-29-03-2024",
+  "version": "2.8.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@antmedia/web_player",
-      "version": "2.8.3-ALPHA-29-03-2024",
+      "version": "2.8.2",
       "license": "ISC",
       "dependencies": {
         "@antmedia/videojs-webrtc-plugin": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antmedia/web_player",
-  "version": "2.8.3-ALPHA-29-03-2024",
+  "version": "2.8.2",
   "description": "Ant Media Server Player that can play WebRTC, HLS, DASH",
   "main": "dist/index.js",
   "module": "dist/es/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antmedia/web_player",
-  "version": "2.8.2",
+  "version": "2.8.3-ALPHA-29-03-2024",
   "description": "Ant Media Server Player that can play WebRTC, HLS, DASH",
   "main": "dist/index.js",
   "module": "dist/es/index.js",

--- a/src/web_player.js
+++ b/src/web_player.js
@@ -636,19 +636,26 @@ export class WebPlayer {
 		//hls specific calls
 		if (extension == "m3u8") {
 	        videojs.Vhs.xhr.beforeRequest = (options) => {
+                const queryParams = [];
 
-                let securityParams = this.getSecurityQueryParams();
-                if (!options.uri.includes(securityParams))
-                {
-                    if (!options.uri.endsWith("?"))
-                    {
-                        options.uri = options.uri + "?";
-                    }
-                    options.uri += securityParams;
+                if (!options.uri.includes("subscriberId") && this.subscriberId != null) {
+                    queryParams.push(`subscriberId=${this.subscriberId}`);
                 }
 
+                if (!options.uri.includes("subscriberCode") && this.subscriberCode != null) {
+                    queryParams.push(`subscriberCode=${this.subscriberCode}`);
+                }
+
+                if (!options.uri.includes("token") && this.token != null) {
+                    queryParams.push(`token=${this.token}`);
+                }
+
+                if (queryParams.length > 0) {
+                    const queryString = queryParams.join("&");
+                    options.uri += options.uri.includes("?") ? `&${queryString}` : `?${queryString}`;
+                }
                 Logger.debug("hls request: " + options.uri);
-	            return options;
+
 	        };
 
 


### PR DESCRIPTION
Dont add security parameters if they already exist in m3u8 url.
This change is required because of this PR:
https://github.com/ant-media/Ant-Media-Server/pull/6238

Above PR passes security parameters on server side if adaptive m3u8 is requested.

Without this changes on embedded player parameters are passed 2 times.

